### PR TITLE
'monthly' or 'yearly' and add email to Slack notifications

### DIFF
--- a/salesforce.py
+++ b/salesforce.py
@@ -406,6 +406,8 @@ def add_customer_and_charge(form=None, customer=None):
     amount = form['amount']
     name = '{} {}'.format(form['first_name'], form['last_name'])
     reason = form['reason']
+    period = form['installment_period']
+    email = form['stripeEmail']
     if reason != '':
         reason = ' (encouraged by {})'.format(reason)
 
@@ -413,12 +415,13 @@ def add_customer_and_charge(form=None, customer=None):
 
     if (form['installment_period'] == 'None'):
         print("----One time payment...")
-        msg = '*{}* pledged *${}*{}'.format(name, amount, reason)
+        msg = '*{}* ({}) pledged *${}*{}'.format(name, email, amount, reason)
         notify_slack(msg)
         add_opportunity(form=form, customer=customer)
     else:
         print("----Recurring payment...")
-        msg = '*{}* pledged *${}*{} [recurring]'.format(name, amount, reason)
+        msg = '*{}* ({}) pledged *${}*{} [{}]'.format(name, email, amount,
+                reason, period)
         notify_slack(msg)
         add_recurring_donation(form=form, customer=customer)
     return True


### PR DESCRIPTION
#### What's this PR do?

Changes Slack notifications in two ways: 
1. instead of saying 'recurring' it's now more specific and says either 'monthly' or 'yearly'
1. the payer's email address is included in the notification

#### Why are we doing this? How does it help us?

Helps people respond to donors more quickly. Request from Tristan.

#### How should this be manually tested?

1. ensure that your `env-docker` file has `SLACK_CHANNEL=#stripe` in it
1. `make backing`
1. `make interactive`
1. `C_FORCE_ROOT=True celery -A app.celery worker --loglevel=INFO &`
1. `python3 app.py`
1. Visit these URLs and donate with `4242 4242 4242 4242`, any CVC and any future expiration date:
   - local.texastribune.org/donateform?amount=70
   - local.texastribune.org/memberform?amount=40&installmentPeriod=monthly
   - local.texastribune.org/memberform?amount=40&installmentPeriod=yearly
1. Check Slack to see that the correct information appears there. 

#### Have automated tests been added?

No.

#### Are there performance implications? If adding JS can it be done async? Do images/CSS/JS have cache headers set?

No.

#### What are the relevant tickets?

Request from Tristan.

#### How should this change be communicated to end users?

Tell Tristan that it's done. 

#### Next steps?

N/A