### PR TITLE
add tag manager

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -25,6 +25,13 @@
   {% block extra_script %}
     <script src="{{ url_for('static', filename='js/all.js') }}"></script>
   {% endblock %}
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P5L2Z5Z');</script>
+  <!-- End Google Tag Manager -->
   <script>
     (function() {
       var _fbq = window._fbq || (window._fbq = []);
@@ -71,6 +78,10 @@
   </script>
 </head>
 <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P5L2Z5Z"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
   {% block content %}
   <section class="masthead">
     <a href="http://www.texastribune.org/">


### PR DESCRIPTION
See this [PR](https://github.com/texastribune/texastribune/pull/1957) on texastribune for more details.

To test:
View the page source on the following, and ensure that "Google Tag Manager" appears 4 times. There should be a `<script>` inside the `<head>` and a `<noscript><iframe>` right underneath the `<body>`.

It should appear on the `/donateform` `/blastform` and `/memberform`