### PR TITLE
add note/styles to let users know they will be prompted for billing e…

### DIFF
--- a/static/sass/_blast.scss
+++ b/static/sass/_blast.scss
@@ -22,6 +22,16 @@
     width: 100%;
   }
 
+  input[name="subscriber_email"] {
+    margin-bottom: 0;
+  }
+
+  .form-subtext {
+    font-size: .85em;
+    margin-bottom: 1em;
+    padding: .25em 0 0;
+  }
+
   #pay_fees {
     margin: 0px;
     width: 20px;

--- a/templates/blast-form.html
+++ b/templates/blast-form.html
@@ -34,8 +34,9 @@
         </div>
         <div class="row">
           <div class="form-section nine">
-            {{ form.subscriber_email.label }}<br>
+            {{ form.subscriber_email.label }}
               {{ form.subscriber_email(maxlength=70) }}
+              <p class="form-subtext">&raquo; You will be prompted for the billing email address at checkout.</p>
           </div>
         </div>
         <div class="row">


### PR DESCRIPTION
Adds a note to let users know they'll be prompted for the billing address later. This should clear up confusion about users putting in the billing email address instead of the address for the person they are setting up the subscription for.

![image](https://cloud.githubusercontent.com/assets/2228508/23082040/3516bd4c-f51d-11e6-82ff-825c8e2d2e0a.png)

Per this task: https://3.basecamp.com/3098728/buckets/736178/todos/379371725