### PR TITLE
Remove amount labels for Circle-level donations

### DIFF
--- a/static/js/all.js
+++ b/static/js/all.js
@@ -24,11 +24,11 @@ var display_level = function() {
     // detemine level and update text based on yearly frequency
     if (input_amount == 10) {
       level_label.text('Student');
-    } else if (input_amount >= 35 && input_amount <= 100) {
+    } else if (input_amount >= 35 && input_amount <= 99) {
       level_label.text('Informed');
-    } else if (input_amount >= 101 && input_amount <= 500) {
+    } else if (input_amount >= 100 && input_amount <= 499) {
       level_label.text('Engaged');
-    } else if (input_amount >= 501 && input_amount <= 999) {
+    } else if (input_amount >= 500 && input_amount <= 999) {
       level_label.text('Involved');
     } else if (input_amount >= 1000 && input_amount <= 2499) {
       level_label.text('Editor\'s Circle');

--- a/static/js/all.js
+++ b/static/js/all.js
@@ -7,43 +7,35 @@ var display_level = function() {
 
   if (frequency == 'monthly') {
     // detemine level and update text based on monthly frequency
-    if (input_amount > 3 && input_amount <= 5) {
-      level_label.text('Enthusiast');
-    } else if (input_amount > 5 && input_amount <= 12) {
-      level_label.text('Activist');
-    } else if (input_amount > 12 && input_amount <= 21) {
-      level_label.text('Advocate');
-    } else if (input_amount > 21 && input_amount <= 42) {
-      level_label.text('Diplomat');
-    } else if (input_amount > 42 && input_amount <= 83) {
-      level_label.text('Benefactor');
-    } else if (input_amount > 83 && input_amount <= 208) {
-      level_label.text("Editor's Circle");
-    } else if (input_amount > 208 && input_amount <= 416) {
+    if (input_amount >= 3 && input_amount <= 8) {
+      level_label.text('Informed');
+    } else if (input_amount >= 9 && input_amount <= 41) {
+      level_label.text('Engaged');
+    } else if (input_amount >= 42 && input_amount <= 83) {
+      level_label.text('Involved');
+    } else if (input_amount >= 84 && input_amount <= 208) {
+      level_label.text('Editor\'s Circle');
+    } else if (input_amount >= 209 && input_amount <= 416) {
       level_label.text('Leadership Circle');
-    } else if (input_amount > 416) {
-      level_label.text("Chairman's Circle");
+    } else if (input_amount >= 417) {
+      level_label.text('Chairman\'s Circle');
     }
   } else {
     // detemine level and update text based on yearly frequency
     if (input_amount == 10) {
       level_label.text('Student');
-    } else if (input_amount > 35 && input_amount <= 59) {
-      level_label.text('Enthusiast');
-    } else if (input_amount > 59 && input_amount <= 149) {
-      level_label.text('Activist');
-    } else if (input_amount > 149 && input_amount <= 249) {
-      level_label.text('Advocate');
-    } else if (input_amount > 249 && input_amount <= 499) {
-      level_label.text('Diplomat');
-    } else if (input_amount > 499 && input_amount <= 999) {
-      level_label.text('Benefactor');
-    } else if (input_amount > 999 && input_amount <= 2499) {
-      level_label.text("Editor's Circle");
-    } else if (input_amount > 2499 && input_amount <= 4999) {
+    } else if (input_amount >= 35 && input_amount <= 100) {
+      level_label.text('Informed');
+    } else if (input_amount >= 101 && input_amount <= 500) {
+      level_label.text('Engaged');
+    } else if (input_amount >= 501 && input_amount <= 999) {
+      level_label.text('Involved');
+    } else if (input_amount >= 1000 && input_amount <= 2499) {
+      level_label.text('Editor\'s Circle');
+    } else if (input_amount >= 2500 && input_amount <= 4999) {
       level_label.text('Leadership Circle');
-    } else if (input_amount > 4999) {
-      level_label.text("Chairman's Circle");
+    } else if (input_amount >= 5000) {
+      level_label.text('Chairman\'s Circle');
     }
   }
 };

--- a/static/js/all.js
+++ b/static/js/all.js
@@ -18,11 +18,11 @@ var display_level = function() {
     } else if (input_amount > 42 && input_amount <= 83) {
       level_label.text('Benefactor');
     } else if (input_amount > 83 && input_amount <= 208) {
-      level_label.text("Editor's Circle - $3,000 pledge");
+      level_label.text("Editor's Circle");
     } else if (input_amount > 208 && input_amount <= 416) {
-      level_label.text('Leadership Circle - $7,500 pledge');
+      level_label.text('Leadership Circle');
     } else if (input_amount > 416) {
-      level_label.text("Chairman's Circle - $15,000 pledge");
+      level_label.text("Chairman's Circle");
     }
   } else {
     // detemine level and update text based on yearly frequency
@@ -39,11 +39,11 @@ var display_level = function() {
     } else if (input_amount > 499 && input_amount <= 999) {
       level_label.text('Benefactor');
     } else if (input_amount > 999 && input_amount <= 2499) {
-      level_label.text("Editor's Circle - $3,000 pledge");
+      level_label.text("Editor's Circle");
     } else if (input_amount > 2499 && input_amount <= 4999) {
-      level_label.text('Leadership Circle - $7,500 pledge');
+      level_label.text('Leadership Circle');
     } else if (input_amount > 4999) {
-      level_label.text("Chairman's Circle - $15,000 pledge");
+      level_label.text("Chairman's Circle");
     }
   }
 };

--- a/tests.py
+++ b/tests.py
@@ -293,7 +293,7 @@ def test__format_blast_rdo():
             'npe03__Installments__c': 0,
             'npe03__Open_Ended_Status__c': 'Open',
             'Stripe_Description__c': 'Monthly Blast Subscription',
-            'Stripe_Agreed_to_pay_fees__c': False,
+            'Stripe_Agreed_to_pay_fees__c': True,
             'Type__c': 'The Blast',
             'Billing_Email__c': 'dcraigmile+test6@texastribune.org',
             'Blast_Subscription_Email__c': 'subscriber@foo.bar',


### PR DESCRIPTION
## What's this PR do?
Removes the dollar amount after a donation's "level" description if it's a Circle-qualifying amount (for monthly and yearly donations).

Also updates what amounts the level names correspond to, per membership.

Also fixes a broken test.

## Why are we doing this? How does it help us?
It's a request from Terry and Rebecca related to the support-page revamp. Users can donate Circle-level amounts without being fixed on a three-year schedule (unless they cancel, it's just perpetuity). Therefore, it was misleading to specify a specific pledge amount.

## How should this be manually tested?
+ `/memberform?installmentPeriod=yearly&amount=5000` and verify there is nothing after "Chairman's Circle."
+ `http://local.texastribune.org/memberform?installmentPeriod=monthly&amount=500` and verify there is nothing after "Chairman's Circle."

Now, let's test that donation amounts correspond to the proper levels. Here are the levels:
+ Student - $10 yearly 
+ Informed - $3-$8 monthly; $35 - $99 yearly 
+ Engaged - $9-$41 monthly; $100-$499 yearly 
+ Involved - $42-$83 monthly; $500-$999 yearly

Visit `http://local.texastribune.org/memberform?installmentPeriod=FREQ&amount=AMT` with FREQ set to both "monthly" and "yearly" and with various values for AMT. Verify the page shows the proper level name.

## Have automated tests been added?
No. But it looks like there are broken tests from previous code changes. I put in a ticket to fix those.

## Has this been tested on mobile?
NA

## Are there performance implications?
NA

## What are the relevant tickets?
Off-sprint

## How should this change be communicated to end users?
NA

## Next steps?
NA

## Smells?
NA

## TODOs:
NA

## Your TODO here
Has the relevant documentation/wiki been updated?
NA

## Technical debt note
NA