### PR TITLE
Make yearly/monthly donations input editable

### DIFF
--- a/templates/includes/display_levels_js.html
+++ b/templates/includes/display_levels_js.html
@@ -1,3 +1,7 @@
 <script>
   window.onload = display_level();
+
+  $('#amount').keyup(function() {
+    display_level();
+  });
 </script>

--- a/templates/member-form.html
+++ b/templates/member-form.html
@@ -21,7 +21,7 @@
         <div class="form-section three">
           <label>{% if installment_period == 'yearly' %}Annual{% endif %}{% if installment_period == 'monthly' %}Monthly{% endif %} Amount</label><br>
             <span class="dollar">$</span>
-              {{ form.amount(readonly=true, value=amount, class="dollar uneditable") }}
+              {{ form.amount(value=amount, class="dollar") }}
           {% if installment_period == 'yearly' %}
             {{ form.openended_status }}
           {% else %}


### PR DESCRIPTION
#### What's this PR do?
Makes it so the box on `memberform` showing the dollar amount is editable like it is on `donateform`. This is a request from Terry, Rebecca and Erin.

#### Why are we doing this? How does it help us?
To give the user more choice. It was decided this would be best for SMD 2017.

#### How should this be manually tested?
Go to `local.texastribune.org/memberform?installmentPeriod=monthly&amount=500` and verify the amount input box is editable. Try entering a non-numeric value and verify the form does not let you submit payment.

Try this with `installmentPeriod=yearly` as well -- and if you have time, with a partial-dollar amount.

#### Have automated tests been added?
No.

#### Has this been tested on mobile?
NA.

#### Are there performance implications?
No.

#### What are the relevant tickets?
Off-sprint SMD request.

#### How should this change be communicated to end users?
They'll have more choice.

#### Next steps?
None.

#### Smells?
None.

#### TODOs:
None.

#### Has the relevant documentation/wiki been updated?
NA.

#### Technical debt note
Same.