### PR TITLE
Use Stripe nonprofit rate

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,3 +1,3 @@
 FROM texastribune/checkout
 
-RUN pip3 install pytest pytest-cov ipdb six==1.10.0 responses
+RUN pip3 install pytest pytest-cov ipdb==0.10.2 six==1.10.0 responses

--- a/batch.py
+++ b/batch.py
@@ -48,17 +48,16 @@ def amount_to_charge(entry):
     """
     Determine the amount to charge. This depends on whether the payer agreed
     to pay fees or not. If they did then we add that to the amount charged.
-    Stripe charges 2.9% + $0.30.
+    Stripe charges 2.2% + $0.30.
 
     Stripe wants the amount to charge in cents. So we multiply by 100 and
     return that.
     """
     amount = float(entry['Amount'])
     if entry['Stripe_Agreed_to_pay_fees__c']:
-        fees = amount * .029 + .30
+        total = (amount + .30) / (1 - 0.022)
     else:
-        fees = 0
-    total = amount + fees
+        total = amount
     total_in_cents = total * 100
 
     return int(total_in_cents)

--- a/batch.py
+++ b/batch.py
@@ -52,6 +52,8 @@ def amount_to_charge(entry):
 
     Stripe wants the amount to charge in cents. So we multiply by 100 and
     return that.
+
+    https://support.stripe.com/questions/can-i-charge-my-stripe-fees-to-my-customers
     """
     amount = float(entry['Amount'])
     if entry['Stripe_Agreed_to_pay_fees__c']:

--- a/static/js/all.js
+++ b/static/js/all.js
@@ -75,20 +75,18 @@ var listen_for_installments = function() {
   });
 };
 
-var pay_fee_amount = function() {
-  var input_amount = $('input[name="amount"]').val();
-  var pay_fee_element = $('#pay-fee-amount span');
+var payFeeAmount = function() {
+  var inputAmount = $('input[name="amount"]').val(),
+      payFeeElement = $('#pay-fee-amount span');
 
-  // Calculate the Stripe fee per charge
-  // https://stripe.com/us/pricing
-  input_amount *= 0.029;
-  input_amount += 0.30;
-
-  input_amount = Math.round(input_amount * 100) / 100;
+  // https://support.stripe.com/questions/can-i-charge-my-stripe-fees-to-my-customers
+  inputAmount *= 0.022;
+  inputAmount += 0.30;
+  inputAmount = Math.ceil(inputAmount * 100) / 100;
 
   // Make sure to always get two decimal places
-  input_amount = input_amount.toFixed(2);
+  inputAmount = inputAmount.toFixed(2);
 
   // Add a dollar sign
-  pay_fee_element.text('$' + input_amount);
+  payFeeElement.text('$' + inputAmount);
 };

--- a/static/js/all.js
+++ b/static/js/all.js
@@ -75,18 +75,13 @@ var listen_for_installments = function() {
   });
 };
 
+
+// https://support.stripe.com/questions/can-i-charge-my-stripe-fees-to-my-customers
 var payFeeAmount = function() {
-  var inputAmount = $('input[name="amount"]').val(),
+  var goalAmount = parseFloat($('input[name="amount"]').val()),
+      totalAmount = (goalAmount + .30) / (1 - 0.022);
+      feeAmount = Math.floor((totalAmount - goalAmount) * 100) / 100,
       payFeeElement = $('#pay-fee-amount span');
 
-  // https://support.stripe.com/questions/can-i-charge-my-stripe-fees-to-my-customers
-  inputAmount *= 0.022;
-  inputAmount += 0.30;
-  inputAmount = Math.ceil(inputAmount * 100) / 100;
-
-  // Make sure to always get two decimal places
-  inputAmount = inputAmount.toFixed(2);
-
-  // Add a dollar sign
-  payFeeElement.text('$' + inputAmount);
+  payFeeElement.text('$' + feeAmount.toFixed(2));
 };

--- a/templates/includes/display_pay_fees.html
+++ b/templates/includes/display_pay_fees.html
@@ -1,9 +1,9 @@
 <script>
-  window.onload = pay_fee_amount();
+  window.onload = payFeeAmount();
 
   window.onload = listen_for_fee_check();
 
   $('input[name="amount"]').keyup(function() {
-    pay_fee_amount();
+    payFeeAmount();
   });
 </script>

--- a/tests.py
+++ b/tests.py
@@ -676,7 +676,7 @@ def test_amount_to_charge_cents_and_fees_true():
     foo['Stripe_Agreed_to_pay_fees__c'] = True
 
     actual = amount_to_charge(foo)
-    expected = 1110
+    expected = 1104
     assert actual == expected
 
 
@@ -685,10 +685,8 @@ def test_amount_to_charge_just_fees_true():
     foo['Amount'] = 10
     foo['Stripe_Agreed_to_pay_fees__c'] = True
 
-    # 10 * 2.9% + $0.30 = $0.59
-
     actual = amount_to_charge(foo)
-    expected = 1059
+    expected = 1053
     assert actual == expected
 
 


### PR DESCRIPTION
#### What's this PR do?
Refactors our fee calculation per this [formula](https://support.stripe.com/questions/can-i-charge-my-stripe-fees-to-my-customers) to use Stripe's nonprofit rate.

#### Why are we doing this? How does it help us?
So we can make more money.

#### How should this be manually tested?
For the front end:
1. Go to `/donateform` and enter any valid numeric amount.
2. Put the following formula in a calculator, replacing **amount** with what you entered in step 1: `(amount + .30) / (1 - 0.022)`. This is total transaction amount, including the fee. Round it to two decimal places, truncating toward zero (for example, 35.6877 would be 35.68).
3. To get the amount of just the fee, subtract the amount from step 1 from the amount from step 2.
4. Confirm this is the "agree to pay fees" amount displayed on `/donateform`.
5. Repeat these steps for a few different amounts -- some with decimals, some without.
6. If you're paranoid and want to triple check, open `tests.py`, find `test_amount_to_charge_cents_and_fees_true()`, change `foo['Amount']` to what you entered in step 1, change `expected` to the amount from step 2 (in cents) and confirm the test passes.

#### Have automated tests been added?
Existing ones updated.

#### Has this been tested on mobile?
NA.

#### Are there performance implications?
No.

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/451886346

#### How should this change be communicated to end users?
NA.

#### Next steps?
None.

#### Smells?
None.

#### TODOs:
None.

#### Has the relevant documentation/wiki been updated?
@x110dc I looked for a master doc for this app in the wiki and couldn't find one. Am I dumb?

#### Technical debt note
Same.