### PR TITLE
Use built-in animations for marking success/failure of Apple Pay

### DIFF
--- a/templates/includes/stripe_checkout_js.html
+++ b/templates/includes/stripe_checkout_js.html
@@ -121,8 +121,10 @@
       var session = Stripe.applePay.buildSession(paymentRequest,
         function(result, completion) {
           appendFormInputs(result.token.id, result.shippingContact.emailAddress);
+          completion(ApplePaySession.STATUS_SUCCESS);
           $form.submit();
       }, function(error) {
+        completion(ApplePaySession.STATUS_FAILURE);
         window.location.href = '/error';
       });
 

--- a/templates/includes/stripe_checkout_js.html
+++ b/templates/includes/stripe_checkout_js.html
@@ -124,7 +124,6 @@
           completion(ApplePaySession.STATUS_SUCCESS);
           $form.submit();
       }, function(error) {
-        completion(ApplePaySession.STATUS_FAILURE);
         window.location.href = '/error';
       });
 


### PR DESCRIPTION
#### What's this PR do?
Uses Stripe's built-in features to add either a green checkmark or red "X" to the Apple Pay modal to denote whether the transaction was successful.

#### Why are we doing this? How does it help us?
It's an easy drop-in feature that actually smooths out the user experience quite a bit.

#### How should this be manually tested?
This assumes you still have the local sandbox environment set up with the test Visa card.

1. Fire up ngrok: `ngrok http 80`
2. Open Safari and go to `/donateform`
3. Enter any amount, hit the Apple Pay button and confirm you get a checkmark on the modal before being sent to `/charge`.
4. There isn't a great way to test the failure animation locally. Once this is deployed, though, I can make a donation with the test card, which will prompt that action.

#### Have automated tests been added?
No.

#### Has this been tested on mobile?
I can't because of my Android situation, but we can look at it on the bat phone when I get out of Alabama.

#### Are there performance implications?
No.

#### What are the relevant tickets?
Off-sprint.

#### How should this change be communicated to end users?
They'll be happy with our fun UX improvements.

#### Next steps?
None.

#### Smells?
None.

#### TODOs:
None.

#### Has the relevant documentation/wiki been updated?
NA.

#### Technical debt note
Same.