### PR TITLE
Use nonprofit formula for Blast's fees value

### DIFF
--- a/static/js/blast.js
+++ b/static/js/blast.js
@@ -31,20 +31,12 @@ var listen_for_installments = function() {
   });
 };
 
-var pay_fee_amount = function() {
-  var input_amount = $('select[name="amount"]').val();
-  var pay_fee_element = $('#pay-fee-amount span');
+// https://support.stripe.com/questions/can-i-charge-my-stripe-fees-to-my-customers
+var payFeeAmount = function() {
+  var goalAmount = parseFloat($('select[name="amount"]').val()),
+      totalAmount = (goalAmount + .30) / (1 - 0.022);
+      feeAmount = Math.floor((totalAmount - goalAmount) * 100) / 100,
+      payFeeElement = $('#pay-fee-amount span');
 
-  // Calculate the Stripe fee per charge
-  // https://stripe.com/us/pricing
-  input_amount *= 0.029;
-  input_amount += 0.30;
-
-  input_amount = Math.round(input_amount * 100) / 100;
-
-  // Make sure to always get two decimal places
-  input_amount = input_amount.toFixed(2);
-
-  // Add a dollar sign
-  pay_fee_element.text('$' + input_amount);
+  payFeeElement.text('$' + feeAmount.toFixed(2));
 };

--- a/templates/blast-form.html
+++ b/templates/blast-form.html
@@ -68,12 +68,13 @@
     {% include 'includes/blast_stripe_checkout_js.html' %}
   </div>
   <script>
-    window.onload = pay_fee_amount();
-
-    window.onload = listen_for_fee_check();
+    window.onload = function() {
+      payFeeAmount();
+      listen_for_fee_check();
+    };
 
     $('select[name="amount"]').change(function() {
-      pay_fee_amount();
+      payFeeAmount();
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
Stripe gives us the nonprofit rate for Blast fees, as well. So people buying a subscription and checking the "agree to pay fees" box have been getting charged at that lower rate. However, the formula on the front-end has still been showing the fees amount at the original, non-nonprofit rate. This PR fixes that.

(Nothing serious -- it means people have actually been getting charged less than they expected.)

Testing:
- On `/blastform`, check that the fee amount for each option in the "subscription plan" dropdown is the same as when calculated with [this formula](https://github.com/texastribune/salesforce-stripe/blob/master/batch.py#L47-L65).
- Verify that if you select a different option from the dropdown, the fees value updates.