### PR TITLE
disable CSRF

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,12 +8,14 @@ def bool_env(val):
     """Replaces string based environment values with Python booleans"""
     return True if os.environ.get(val, False) == 'True' else False
 
+
 TIMEZONE = os.getenv('TIMEZONE', "US/Central")
 
 #######
 # Flask
 #
 FLASK_SECRET_KEY = os.getenv('FLASK_SECRET_KEY')
+WTF_CSRF_ENABLED = False
 
 ########
 # Celery

--- a/templates/blast-form.html
+++ b/templates/blast-form.html
@@ -23,7 +23,6 @@
   </header>
   <div class="grid_container blast_main">
     <form action="/submit-blast" method="post" class="blastform grid_separator--l">
-      {{ form.csrf_token }}
       <div class="form-outer-section outer-section narrow">
 
         <header class="grid_separator--l">

--- a/templates/circle-form.html
+++ b/templates/circle-form.html
@@ -14,7 +14,6 @@
       <p>Thank you for supporting The Texas Tribune by becoming a circle member! As a 501(c)(3) nonprofit organization, our work is made possible through the generosity of members and donors like you.</p>
     </header>
     <form id="form" action="/charge" method="post">
-      {{ form.csrf_token }}
       <div class="grid_row grid_wrap--l grid_wrap--reverse">
         <div class="col_6">
           {% include 'includes/form_inner.html' %}

--- a/templates/donate-form.html
+++ b/templates/donate-form.html
@@ -11,7 +11,6 @@
 
   <div class="main grid_container--xl">
     <form action="/charge" method="post">
-      {{ form.csrf_token }}
       <header class="grid_separator--l">
         <h1>Confirm your donation</h1>
         <p>Thank you for supporting The Texas Tribune! As a 501(c)(3) nonprofit organization, our work is made possible through the generosity of members and donors like you. If you'd prefer to become a member, you can set up a recurring <a href="/memberform?installmentPeriod=monthly&amount={{ amount }}">monthly</a> or <a href="/memberform?installmentPeriod=yearly&amount={{ amount }}">annual</a> donation.</p>

--- a/templates/member-form.html
+++ b/templates/member-form.html
@@ -10,7 +10,6 @@
   {{ super() }}
   <div class="main grid_container--xl">
     <form action="/charge" method="post">
-      {{ form.csrf_token }}
       <header class="grid_separator--l">
         <h1>Confirm your donation</h1>
         <p>Thank you for supporting The Texas Tribune by becoming a member! As a 501(c)(3) nonprofit organization, our work is made possible through the generosity of members and donors like you.</p>


### PR DESCRIPTION
#### What's this PR do?

Disables CSRF.

#### Why are we doing this? How does it help us?

Every once in a while a user will get a CSRF error. This avoids that. It's not doing us any good anyway since there's no session in this app.

#### How should this be manually tested?

Try any URL for the app and make sure you don't get a CSRF error in the log. For example:

http://local.texastribune.org/memberform?campaignId=blah&amount=85

#### Have automated tests been added?

No.

#### Has this been tested on mobile?

No.

#### Are there performance implications?

No.

#### What are the relevant tickets?

Off sprint task.

#### How should this change be communicated to end users?

N/A

#### Next steps?

N/A

#### Smells?

None.

#### Has the relevant documentation/wiki been updated?

No.

#### Technical debt note

Same.