### PR TITLE
show one-time option on monthly form, fix styles

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -25,7 +25,7 @@ class BaseForm(FlaskForm):
 
 class MemberForm(BaseForm):
     openended_status = RadioField(u'Membership Duration',
-        choices=[('Open', 'Sustaining'), ('None', 'One Year')],
+        choices=[('Open', 'Sustaining'), ('None', 'One Time')],
         default='Open')
 
 

--- a/static/sass/_theme.scss
+++ b/static/sass/_theme.scss
@@ -81,10 +81,12 @@ input {
 input[type='text'] {
   width: 100%;
   border: 1px solid $color-gray-light;
+
   &.dollar {
-    margin: $size-b 0;
-    padding: 0 $size-b/2;
-    width: 140px;
+    margin: 0 0 $size-b/2;
+    padding: 0 $size-b/2 0 2rem;
+    position: inherit;
+    width: 100%;
   }
 
   &.uneditable {
@@ -127,7 +129,8 @@ input::-webkit-inner-spin-button, {
   color: $color-black-pure;
   font-size: $size-giant;
   font-weight: 700;
-  margin: 0;
+  margin: 0 0 0 $size-b/2;
+  position: absolute;
 }
 
 .form__box {
@@ -155,7 +158,6 @@ input::-webkit-inner-spin-button, {
 
 // styles for openended status radio buttons on yearly member form
 #openended_status {
-  padding: $size-b 0;
   li {
     padding-left: $size-b/2;
   }

--- a/templates/member-form.html
+++ b/templates/member-form.html
@@ -29,13 +29,9 @@
                 <span class="dollar">$</span>
                 {{ form.amount(value=amount, class="dollar") }}
               </div>
-            {% if installment_period == 'yearly' %}
               <div class="col">
               {{ form.openended_status }}
               </div>
-            {% else %}
-              {{ form.openended_status(class='visually-hidden') }}
-            {% endif %}
             {{ form.installments(value=installments) }}
             </div>
             <p class="subtext grid_separator">Sustaining membership allows you to support journalism that matters with an ongoing gift from your credit card. It auto-renews each {% if installment_period == 'yearly' %}year{% else %}month{% endif %}, and helps eliminate renewal mailings or lapses in your membership.</p>


### PR DESCRIPTION
This allows the user to switch to a "one-time" donation from the monthly donation URL — just as they can for the yearly donation. While we don't want to encourage one-time donations, it's better to have a user give one-time than drop off entirely because they don't want to set up a recurring charge and can't figure out how to get to a one-time donation place, which they can't find at all from this URL right now.

I also fixed the dollar sign and input field, so that it expands to fill the available width and doesn't go to two lines when the screen shrinks.

To test: 
Go to a monthly donation url `/memberform?installmentPeriod=monthly&amount=15` and make sure you can process a one-time donation

Resize and make sure that the amount input looks good on all sizes