### PR TITLE
Ensure 1password doesn't change amount on autofill

### DIFF
--- a/templates/blast-form.html
+++ b/templates/blast-form.html
@@ -21,7 +21,7 @@
       </div>
     </div>
   </header>
-  <div class="grid_container blast_main">
+  <div id="blast" class="grid_container blast_main">
     <form action="/submit-blast" method="post" class="blastform grid_separator--l">
       <input name="campaign_id" id="campaign_id" value="{{ campaign_id  }}" type="hidden">
       <div class="form-outer-section outer-section narrow">

--- a/templates/blast-vip.html
+++ b/templates/blast-vip.html
@@ -21,7 +21,7 @@
       </div>
     </div>
   </header>
-  <div class="grid_container blast_main">
+  <div id="blast-vip" class="grid_container blast_main">
     <form action="/submit-blast-vip" method="post" class="blastform grid_separator--l">
       <input name="campaign_id" id="campaign_id" value="{{ campaign_id  }}" type="hidden">
       <div class="form-outer-section outer-section narrow">

--- a/templates/circle-form.html
+++ b/templates/circle-form.html
@@ -8,7 +8,7 @@
 
 {% block content %}
   {{ super() }}
-  <div class="main grid_container--xl">
+  <div id="circle" class="main grid_container--xl">
     <header class="grid_separator--l">
       <h1>Confirm your circle membership</h1>
       <p>Thank you for supporting The Texas Tribune by becoming a circle member! As a 501(c)(3) nonprofit organization, our work is made possible through the generosity of members and donors like you.</p>
@@ -28,7 +28,7 @@
             <div class="col grid_separator">
               <label>{% if installment_period == 'yearly' %}Annual{% endif %}{% if installment_period == 'monthly' %}Monthly{% endif %} Amount</label><br>
               <span class="dollar">$</span>
-                {{ form.amount(readonly=true, value=amount, class="dollar uneditable") }}
+                {{ form.amount(readonly=true, autocomplete="off", value=amount, class="dollar") }}
             </div>
             <div class="col">
               <label>Length</label><br>
@@ -43,7 +43,7 @@
           <div class="grid_row grid_wrap--m">
             <div class="col">
               {{ form.pay_fees.label }}
-                {{ form.pay_fees(checked=False) }}
+                {{ form.pay_fees(checked=False, autocomplete="off") }}
               <p id="pay-fee-amount" class="label-info"><span></span>{% if installment_period == 'yearly' %} yearly{% endif %}{% if installment_period == 'monthly' %} monthly{% endif %}</p>
               <p id="pay-fee-info">Paying these tax-deductible fees directs more money in support of the Tribune’s mission.</p>
             </div>

--- a/templates/donate-form.html
+++ b/templates/donate-form.html
@@ -27,13 +27,13 @@
             <div class="col">
               <label>Amount</label><br>
                 <span class="dollar">$</span>
-                  {{ form.amount(value=amount, class="dollar") }}
+                  {{ form.amount(value=amount, autocomplete="off", class="dollar") }}
             </div>
           </div>
           <div class="grid_row grid_wrap--m">
             <div class="col">
               {{ form.pay_fees.label }}
-                {{ form.pay_fees(checked=False) }}
+                {{ form.pay_fees(checked=False, autocomplete="off") }}
               <p id="pay-fee-amount" class="label-info"><span></span>{% if installment_period == 'yearly' %} yearly{% endif %}{% if installment_period == 'monthly' %} monthly{% endif %}</p>
             </div>
           </div>

--- a/templates/includes/stripe_checkout_js.html
+++ b/templates/includes/stripe_checkout_js.html
@@ -8,6 +8,8 @@
         $formError = $('.form-error'),
         $formErrorMessage = $('.error-form-message'),
         $chargeDescription = $('#description'),
+        isCircleForm = document.querySelector('#circle'),
+        isBlastForm = document.querySelector('#blast') || document.querySelector('#blast-vip'),
         handler;
 
     function bothNamesExist() {
@@ -43,6 +45,14 @@
       }
     }
 
+    function makeAmountReadOnly() {
+      $amount.prop('readonly', true);
+    }
+
+    function makeAmountEditable() {
+      $amount.prop('readonly', false);
+    }
+
     function bindEvents() {
       $('#customButton').click(function(e) {
         e.preventDefault();
@@ -52,6 +62,10 @@
         if (formIsValid()) {
           $formError.hide();
           $formErrorMessage.text('');
+
+          if (!isCircleForm && !isBlastForm) {
+            makeAmountReadOnly();
+          }
 
           handler.open({
             name: 'The Texas Tribune',
@@ -76,6 +90,10 @@
           $form.submit();
         },
         closed: function() {
+          if (!isCircleForm && !isBlastForm) {
+            makeAmountEditable();
+          }
+
           removeFormInputs();
         }
       });

--- a/templates/member-form.html
+++ b/templates/member-form.html
@@ -27,7 +27,7 @@
             <div class="grid_row grid_wrap--m">
               <div class="col">
                 <span class="dollar">$</span>
-                {{ form.amount(value=amount, class="dollar") }}
+                {{ form.amount(value=amount, autocomplete="off", class="dollar") }}
               </div>
               <div class="col">
               {{ form.openended_status }}
@@ -39,7 +39,7 @@
           <div class="grid_row grid_wrap--m">
             <div class="col">
               {{ form.pay_fees.label }}
-                {{ form.pay_fees(checked=False) }}
+                {{ form.pay_fees(checked=False, autocomplete="off") }}
               <p id="pay-fee-amount" class="label-info"><span></span>{% if installment_period == 'yearly' %} yearly{% endif %}{% if installment_period == 'monthly' %} monthly{% endif %}</p>
             </div>
             <div class="col">


### PR DESCRIPTION
#### What's this PR do?
Prevents 1password's credit-card autofill feature from changing the amount a user originally entered. There's weirdness between 1Password and the Stripe modal: Whatever card-expiration month the former fills in also gets dropped into the Flask form's `amount` input.

Anna H. reported this and sent along some code a VOSD developer wrote to fix it. It seemed overly complicated, though: I'm simply setting the amount field to `readonly`when the Stripe modal is open. It seems to work.

#### Why are we doing this? How does it help us?
To ensure people don't give the wrong amount.

#### How should this be manually tested?
- `make backing`
- `make interactive`
- `python3 app.py`
- Add a credit card to 1password and ensure you have the browser extension installed
- On both `/donateform` and `/memberform`, fill out the form as normal, then click "Pay By Card." Use 1password to autofill the credit-card information. Confirm that doing so does not change the input amount in the form below the overlay. Close the Stripe modal and confirm the amount field is editable again.
- On `/circleform`, once again fill out the form, hit "Pay by Card," and autofill the credit card info with 1password. Confirm the amount in the Flask form does not change. Close the Stripe modal and confirm the amount field is still read-only.
- Try checking out on `/blastform` and `/blast-vip`, just to ensure nothing seems off. (I tested there, too.)
- If an iPhone user with the 1password app installed can try this (this branch is on staging), that'd be grand. I'll take care of Android.

#### Have automated tests been added?
No.

#### Has this been tested on mobile?
I tested successfully on desktop Chrome, Firefox and Safari. I feel pretty good about those results.

#### Are there performance implications?
No.

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/784219601

#### How should this change be communicated to end users?
NA.

#### Next steps?
NA.

#### Smells?
Toggling read-only on the amount input is a slight smell, but it's not much code, either.

#### TODOs:
NA.

#### Has the relevant documentation/wiki been updated?
NA.

#### Technical debt note
A tiny bit more.
