### PR TITLE
fix for multiple emails being sent about the same duplicate account

### DIFF
--- a/salesforce.py
+++ b/salesforce.py
@@ -61,7 +61,7 @@ def send_multiple_account_warning():
     Send the warnings about multiple accounts.
     """
 
-    for email in WARNINGS:
+    for email in list(WARNINGS.keys()):
         count = WARNINGS[email]
         body = """
         {} accounts were found matching the email address <{}>
@@ -78,6 +78,8 @@ def send_multiple_account_warning():
                 subject="Multiple accounts found for {}".format(email),
                 body=body
                 )
+
+        del WARNINGS[email]
 
 
 def get_email(form):

--- a/tests.py
+++ b/tests.py
@@ -875,5 +875,6 @@ def test_card_error(sf_connection, sf_connection_query, stripe_charge, log,
 @patch('salesforce.send_email')
 def test_multiple_account_warnings(send_email_mock):
     WARNINGS['foo@bar'] = 2
+    WARNINGS['foo@baz'] = 2
     send_multiple_account_warning()
     assert len(WARNINGS) == 0

--- a/tests.py
+++ b/tests.py
@@ -21,7 +21,8 @@ from salesforce import SalesforceConnection
 from salesforce import upsert_customer
 from salesforce import _format_amount
 from salesforce import _format_contact
-
+from salesforce import send_multiple_account_warning
+from salesforce import WARNINGS
 
 # ("Request: ImmutableMultiDict([('Opportunity.Amount', '100'), ('frequency', "
 #  "'until-cancelled'), ('Contact.LastName', 'C'), ('Contact.street', '823 "
@@ -869,3 +870,10 @@ def test_card_error(sf_connection, sf_connection_query, stripe_charge, log,
     print(log.it.call_args_list)
     assert len(log.it.call_args_list) == 9
     assert log.it.call_args_list == expected_call_list
+
+
+@patch('salesforce.send_email')
+def test_multiple_account_warnings(send_email_mock):
+    WARNINGS['foo@bar'] = 2
+    send_multiple_account_warning()
+    assert len(WARNINGS) == 0


### PR DESCRIPTION
#### What's this PR do?

Adds a fix for duplicate emails being sent out for the same account.

#### Why are we doing this? How does it help us?

To stop annoying Anna and the others who read and process those emails.

#### How should this be manually tested?

There's not really a way to manually test it, but I wrote a unit test so run `make test` and make sure it works.

#### Have automated tests been added?

Yes.

#### Has this been tested on mobile?

N/A

#### Are there performance implications?

No

#### What are the relevant tickets?

https://3.basecamp.com/3098728/buckets/736178/todos/784339426

#### How should this change be communicated to end users?

Tell Anna that it's fixed.

#### Next steps?

None.

#### Smells?

No.

#### Has the relevant documentation/wiki been updated?

No.

#### Technical debt note

Less