### PR TITLE
set temporary redirect on blast-vip to standard checkout

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from flask import Flask, render_template, request, send_from_directory
+from flask import Flask, redirect, render_template, request, send_from_directory
 from forms import DonateForm, BlastForm, BlastVIPForm, MemberForm
 from raven.contrib.flask import Sentry
 from sassutils.wsgi import SassMiddleware
@@ -150,19 +150,22 @@ def submit_blast():
 
 @app.route('/blast-vip')
 def the_blastvip_form():
-    form = BlastVIPForm()
-    if request.args.get('amount'):
-        amount = request.args.get('amount')
-    else:
-        amount = 275
-    installment_period = request.args.get('installmentPeriod')
-
-    campaign_id = request.args.get('campaignId', default='')
-
-    return render_template('blast-vip.html', form=form,
-            campaign_id=campaign_id, installment_period=installment_period,
-        openended_status='Open', amount=amount,
-        key=app.config['STRIPE_KEYS']['publishable_key'])
+    return redirect("https://checkout.texastribune.org/blastform", code=302)
+    # This promotion has expired, so we are redirecting it to the regular Blast Checkout
+    # Leaving this code for when we need to reactivate this page for another promo.
+    # form = BlastVIPForm()
+    # if request.args.get('amount'):
+    #     amount = request.args.get('amount')
+    # else:
+    #     amount = 275
+    # installment_period = request.args.get('installmentPeriod')
+    #
+    # campaign_id = request.args.get('campaignId', default='')
+    #
+    # return render_template('blast-vip.html', form=form,
+    #         campaign_id=campaign_id, installment_period=installment_period,
+    #     openended_status='Open', amount=amount,
+    #     key=app.config['STRIPE_KEYS']['publishable_key'])
 
 @app.route('/submit-blast-vip', methods=['POST'])
 def submit_blast_vip():


### PR DESCRIPTION
This PR comments out the route for the `blast-vip` promo page and sets a 302 redirect to the main `blastform` checkout.

This promotion ends on Dec. 31, so we no longer want people who come to this page to be able to sign-up for The Blast at the discounted rate. 

I left the code in the file, but commented out, as I expect we'll resurrect this promotion or another one in the future.

To test —
Go to local.../blast-vip and make sure that it redirects to https://checkout.texastribune.org/blastform with a 302.