### PR TITLE
Add GA tracker for frequency and amount on /charge

### DIFF
--- a/app.py
+++ b/app.py
@@ -233,8 +233,14 @@ def charge():
                 customer=customer)
         print('Validated form of customer {} {} {}'.format(customer_email,
             customer_first, customer_last))
+        ga = {
+            'event_category': 'Support Us',
+            'event_action': 'donation-success',
+            'event_label': request.form['installment_period'] if request.form['installment_period'] != 'None' else 'one-time',
+            'event_value': request.form['amount'],
+        }
         return render_template('charge.html',
-                amount=request.form['amount'])
+                amount=request.form['amount'], ga=ga)
     else:
         message = "There was an issue saving your donation information."
         print('Form validation errors: {}'.format(form.errors))

--- a/app.py
+++ b/app.py
@@ -233,9 +233,8 @@ def charge():
                 customer=customer)
         print('Validated form of customer {} {} {}'.format(customer_email,
             customer_first, customer_last))
+        # give the frequency and amount to template for GA tracking
         ga = {
-            'event_category': 'Support Us',
-            'event_action': 'donation-success',
             'event_label': request.form['installment_period'] if request.form['installment_period'] != 'None' else 'one-time',
             'event_value': request.form['amount'],
         }

--- a/templates/charge.html
+++ b/templates/charge.html
@@ -47,3 +47,15 @@
     </div>
   </div>
 {% endblock %}
+
+{% block bottom_script %}
+  <script>
+    ga('send', {
+      hitType: 'event',
+      eventCategory: '{{ ga.event_category }}',
+      eventAction: '{{ ga.event_action }}',
+      eventLabel: '{{ ga.event_label }}',
+      eventValue: parseInt('{{ ga.event_value }}')
+    });
+  </script>
+{% endblock %}

--- a/templates/charge.html
+++ b/templates/charge.html
@@ -52,8 +52,8 @@
   <script>
     ga('send', {
       hitType: 'event',
-      eventCategory: '{{ ga.event_category }}',
-      eventAction: '{{ ga.event_action }}',
+      eventCategory: 'Support Us',
+      eventAction: 'donation-success',
       eventLabel: '{{ ga.event_label }}',
       eventValue: parseInt('{{ ga.event_value }}')
     });

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -148,5 +148,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   ga('require', 'displayfeatures');
   ga('send', 'pageview');
 </script>
+{% block bottom_script %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
#### What's this PR do?
Adds a GA tracker on `/charge` that records the frequency of a donation (monthly, yearly, one time) and its amount.

#### Why are we doing this? How does it help us?
Request from Erin.

#### How should this be manually tested?
+ Go to `/memberform?amount=50&installmentPeriod=monthly`. Fill out the form with the "sustaining" radio button checked. Submit the form, then view the page source on `/charge`. Scroll to the bottom and confirm you see a `ga('send')` event with `eventLabel: 'monthly'` and `eventValue: parseInt(50)`.
+ Go back in your browser and fill out the form again, this time checking the "one time" radio button. Find the same GA tracker in the `/charge` page source and confirm that `eventLabel` is now `one-time`.
+ Do the same drill with `circleform?&amount=1000&installmentPeriod=monthly&installments=36`. You should see `eventLabel: 'monthly'` and `eventValue: parseInt(1000)`.
+ Finally, fill out `/donateform?amount=123`. Confirm the `/charge GA tracker` has `eventLabel: 'one-time'` and `eventValue: parseInt(123)`.

#### Have automated tests been added?
No.

#### Has this been tested on mobile?
NA.

#### Are there performance implications?
No.

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/817237961

#### How should this change be communicated to end users?
NA.

#### Next steps?
After deployment, I'll touch base with Erin periodically to ensure data is flowing in properly.

#### Smells?
There are some weird edge cases that this tracker won't account for, such as someone messing with the `installments` query parameter on `/circleform` without adjusting `installmentPeriod` in tandem. But again, edge case.

#### TODOs:
NA.

#### Has the relevant documentation/wiki been updated?
I left an inline comment. I think that will suffice.

#### Technical debt note
Same.