### PR TITLE
Upgrade to jQuery 3.x

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -19,9 +19,7 @@
   <link href="{{ url_for('static', filename='css/all.scss.css') }}" rel="stylesheet" type="text/css">
   <script src="//use.typekit.net/ngv2xmw.js"></script>
   <script>try{Typekit.load();}catch(e){}</script>
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-  <script>window.jQuery || document.write('<script src="{{
-  url_for('static', filename='js/jquery.min.js') }}">\x3C/script>')</script>
+  <script src="http://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
   {% block extra_script %}
     <script src="{{ url_for('static', filename='js/all.js') }}"></script>
   {% endblock %}


### PR DESCRIPTION
#### What's this PR do?
Upgrades to jQuery 3.

#### Why are we doing this? How does it help us?
[Security vulnerabilities](https://nvd.nist.gov/vuln/search/results?query=jquery&search_type=all&cves=on&startIndex=0) in older versions.

#### How should this be manually tested?
Visit the following URLs with your browser console open. Click around the forms, making sure validation works and that you're able to successfully complete a charge. Also verify you don't get weird console errors. The Stripe test card number is `4242 4242 4242 4242`, and you can enter any future expiration date and any three-digit number for the security code.
+ `/donateform?amount=50`
+ `/memberform?amount=50&installmentPeriod=monthly`
+ `/circleform?&amount=1000&installmentPeriod=yearly&installments=3`
+ `/blastform`

#### Have automated tests been added?
No.

#### Has this been tested on mobile?
No. jQuery 3 meets all of our browser-support criteria, so we're good.

#### Are there performance implications?
No.

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/877542100

#### How should this change be communicated to end users?
NA.

#### Next steps?
Oh you know, just clean up all the jQuery on texastribune.org.

#### Smells?
There should be a `package.json` in this repo, but whomever originally did the front-end didn't put one in.

#### TODOs:
NA.

#### Has the relevant documentation/wiki been updated?
NA.

#### Technical debt note
Little less.
