### PR TITLE
SMD redirects + smart defaults

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,21 +89,21 @@ def member2_form():
     if installment_period == 'monthly':
         openended_status = 'Open'
         if amount is None:
-            amount = 10
+            amount = '10'
     elif installment_period == 'yearly':
         openended_status = 'Open'
         if amount is None:
-            amount = 50
+            amount = '50'
     elif installment_period == 'once':
         installment_period = 'None'
         openended_status = 'None'
         if amount is None:
-            amount = 20
+            amount = '20'
     else:
         installment_period = 'monthly'
         openended_status = 'Open'
         if amount is None:
-            amount = 10
+            amount = '10'
     
     form.installment_period.default = installment_period
     form.openended_status.default = openended_status

--- a/app.py
+++ b/app.py
@@ -77,31 +77,34 @@ def member_form():
 @app.route('/donate')
 def member2_form():
     form = MemberForm2()
-    if request.args.get('amount'):
-        amount = request.args.get('amount')
-    else:
-        message = "The page you requested can't be found."
-        return render_template('error.html', message=message)
-
-    campaign_id = request.args.get('campaignId', default='')
     installments = 'None'
+    campaign_id = request.args.get('campaignId', default='')
     installment_period = request.args.get('installmentPeriod')
+    amount = request.args.get('amount')
 
     if installment_period is None:
-        installment_period = 'yearly'
+        installment_period = 'monthly'
+    
+    installment_period = installment_period.lower()
+    if installment_period == 'monthly':
         openended_status = 'Open'
+        if amount is None:
+            amount = 10
+    elif installment_period == 'yearly':
+        openended_status = 'Open'
+        if amount is None:
+            amount = 50
+    elif installment_period == 'once':
+        installment_period = 'None'
+        openended_status = 'None'
+        if amount is None:
+            amount = 20
     else:
-        installment_period = installment_period.lower()
-
-        if installment_period == 'yearly' or installment_period == 'monthly':
-            openended_status = 'Open'
-        elif installment_period == 'once':
-            installment_period = 'None'
-            openended_status = 'None'
-        else:
-            installment_period = 'yearly'
-            openended_status = 'Open'
-
+        installment_period = 'monthly'
+        openended_status = 'Open'
+        if amount is None:
+            amount = 10
+    
     form.installment_period.default = installment_period
     form.openended_status.default = openended_status
     form.process()

--- a/app.py
+++ b/app.py
@@ -256,8 +256,6 @@ def charge():
     form = DonateForm(request.form)
     pprint('Request: {}'.format(request))
 
-    print(request.form)
-
     customer_email = request.form['stripeEmail']
     customer_first = request.form['first_name']
     customer_last = request.form['last_name']

--- a/app.py
+++ b/app.py
@@ -15,6 +15,8 @@ from app_celery import make_celery
 
 from pprint import pprint
 
+smd_redirect_url = '/donate'
+
 app = Flask(__name__)
 
 app.secret_key = FLASK_SECRET_KEY
@@ -50,6 +52,8 @@ if app.config['ENABLE_SENTRY']:
 
 @app.route('/memberform')
 def member_form():
+    return redirect(smd_redirect_url, code=302)
+    """
     form = MemberForm()
     if request.args.get('amount'):
         amount = request.args.get('amount')
@@ -68,6 +72,7 @@ def member_form():
         campaign_id=campaign_id, installment_period=installment_period,
         installments=installments, openended_status=openended_status,
         key=app.config['STRIPE_KEYS']['publishable_key'])
+    """
 
 @app.route('/donate')
 def member2_form():
@@ -108,6 +113,8 @@ def member2_form():
 
 @app.route('/donateform')
 def donate_renew_form():
+    return redirect(smd_redirect_url, code=302)
+    """
     form = DonateForm()
     if request.args.get('amount'):
         amount = request.args.get('amount')
@@ -124,6 +131,7 @@ def donate_renew_form():
         installments=installments,
         openended_status=openended_status,
         key=app.config['STRIPE_KEYS']['publishable_key'])
+    """
 
 
 @app.route('/circleform')

--- a/app.py
+++ b/app.py
@@ -93,12 +93,12 @@ def member2_form():
     elif installment_period == 'yearly':
         openended_status = 'Open'
         if amount is None:
-            amount = '50'
+            amount = '75'
     elif installment_period == 'once':
         installment_period = 'None'
         openended_status = 'None'
         if amount is None:
-            amount = '20'
+            amount = '60'
     else:
         installment_period = 'monthly'
         openended_status = 'Open'

--- a/app.py
+++ b/app.py
@@ -15,7 +15,7 @@ from app_celery import make_celery
 
 from pprint import pprint
 
-smd_redirect_url = '/donate'
+smd_redirect_url = '/donate?campaignId=70146000000M0pM'
 
 app = Flask(__name__)
 

--- a/app.py
+++ b/app.py
@@ -79,12 +79,9 @@ def member2_form():
     form = MemberForm2()
     installments = 'None'
     campaign_id = request.args.get('campaignId', default='')
-    installment_period = request.args.get('installmentPeriod')
+    installment_period = request.args.get('installmentPeriod', 'monthly')
     amount = request.args.get('amount')
 
-    if installment_period is None:
-        installment_period = 'monthly'
-    
     installment_period = installment_period.lower()
     if installment_period == 'monthly':
         openended_status = 'Open'


### PR DESCRIPTION
#### What's this PR do?
+ Temporarily redirects `/donateform` and `/memberform` to `/donate`, which will be the SMD campaign page.
+ Makes it so `/donate` doesn't 404 when an amount query parameter is not provided

#### Why are we doing this? How does it help us?
Amanda request so they can better track money earned during SMD.

#### How should this be manually tested?
+ Visit both `/donateform` and `/memberform`. No matter the query params appended to each, they should redirect to `/donate?campaignId=70146000000M0pM`.
+ Visit `/donate` with no params. It should default to $10/month.
+ Visit with an `amount` param but not an `installmentPeriod` one. It should show the amount and default to monthly.
+ Visit with an `installmentPeriod=/monthly/yearly/once` param but not an amount param. If monthly, the amount should be 10. If yearly, 75. If once, 60.
+ Visit with a bogus `installmentPeriod` param and no amount param. It should default to $10/month.
+ Visit with a bogus `installmentPeriod` param but a valid amount param. It should show the amount and default to monthly.

#### Have automated tests been added?
No.

#### Has this been tested on mobile?
NA.

#### Are there performance implications?
No.

#### What are the relevant tickets?
Off-sprint SMD prep.

#### How should this change be communicated to end users?
NA.

#### Next steps?
NA.

#### Smells?
The redirects are temporary, so meh.

#### TODOs:
* [x] Confirm amounts with Amanda.

#### Has the relevant documentation/wiki been updated?
NA.

#### Technical debt note
Same.