### PR TITLE
Upgrade stripe-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ libsass==0.11.2
 pytz==2016.7
 Flask-WTF==0.13.1
 WTForms==2.1
-stripe==1.41.1
+stripe==1.82.1
 celery==3.1.24
 flower==0.9.1
 redis==2.10.5


### PR DESCRIPTION
#### What's this PR do?
Upgrades the `stripe-python` package.

#### Why are we doing this? How does it help us?
For compatibility with Stripe's new front-end code. They introduced a single button that detects your environment and then fires up Apple Pay, Google Pay, Microsoft Pay or browser-saved cards accordingly.

My refactor branch includes this button. I was testing that branch on staging and noticed nothing was posting to the `#stripe` Slack channel when I paid via a browser-saved card. A look at the Heroku logs indicated there were errors processing the token, so I tried upgrading `stripe-python` package -- and now everything works.

I'm doing the upgrade as a separate PR here to keep my refactor PR focused and because it feels good to do things incrementally.

#### How should this be manually tested?
I put this branch on staging and tested sample monthly, yearly and one-time donations; a circle donation; and a Blast payment. Everything reached the `/charge` page and posted to `#stripe` as expected.

So for your tests, run through those same tests, just locally.

@x110dc Is there a way to confirm a Blast payment is successful given those payments don't post to `#stripe`?

#### Have automated tests been added?
No.

#### Has this been tested on mobile?
NA.

#### Are there performance implications?
No.

#### What are the relevant tickets?
Related to ongoing front-end refactor.

#### How should this change be communicated to end users?
NA.

#### Next steps?
Merge into refactor branch.

#### Smells?
NA.

#### TODOs:
NA.

#### Has the relevant documentation/wiki been updated?
NA.

#### Technical debt note
Little less.