### PR TITLE
Do not call Stripe API if customer ID does not exist

### DIFF
--- a/app.py
+++ b/app.py
@@ -113,7 +113,7 @@ def circle_form():
 
 @app.route('/circle-charge', methods=['POST'])
 def circle_charge():
-    form = DonateForm(request.form)
+    form = CircleForm(request.form)
     pprint('Request: {}'.format(request))
 
     customer_email = request.form['stripeEmail']

--- a/forms.py
+++ b/forms.py
@@ -28,6 +28,7 @@ class CircleForm(BaseForm):
     installment_period = HiddenField(u'Installment Period')
 
 class DonateForm(BaseForm):
+    customerId = HiddenField(u'Customer ID', [validators.InputRequired()])
     installment_period = RadioField(u'Installment Period',
         choices=[('yearly', 'Yearly'), ('monthly', 'Monthly'), ('None', 'One Time')])
 


### PR DESCRIPTION
#### What's this PR do?
+ Checks whether the `customerId` field exists in a form submission for retrieving a customer via Stripe.

#### Why are we doing this? How does it help us?
To avoid throttling Sentry and Stripe.

#### How should this be manually tested?
+ `yarn run dev`
+ Fill out the form on `/donate` and confirm you can successfully submit it.
+ Change `customerId` on [this line](https://github.com/texastribune/salesforce-stripe/blob/customer-id/forms.py#L31) to something else.
+ Wait for Flask to restart, then submit the form again. Confirm you get an error/we're sorry page. (This is confirming that Flask does make it to [this statement](https://github.com/texastribune/salesforce-stripe/blob/customer-id/app.py#L259) if the form is invalid.)

#### Have automated tests been added?
No.

#### Has this been tested on mobile?
NA.

#### Are there performance implications?
No.

#### What are the relevant tickets?
Off-sprint.

#### How should this change be communicated to end users?
NA.

#### Next steps?
I'll bring this same validation to the Circle form in the refactor PR.

#### Smells?
In general, the server-side form validation could be stronger in this app. I've left it alone during my refactor efforts and have instead focused on client-side validation. I'd like to handle the server-side stuff in a separate PR.

#### TODOs:
NA.

#### Has the relevant documentation/wiki been updated?
NA.

#### Technical debt note
Same.