### PR TITLE
Better customer ID validation to prevent throttling

### DIFF
--- a/app.py
+++ b/app.py
@@ -244,8 +244,14 @@ def charge():
             gtm['event_value'] = request.form['amount']
             return render_template('charge.html',
                     amount=request.form['amount'], gtm=gtm, bundles=bundles)
-        except stripe.error.InvalidRequestError:
-            return render_template('error.html', message=error_message)
+        except stripe.error.InvalidRequestError as e:
+            body = e.json_body
+            err = body.get('error', {})
+            message = err.get('message', '')
+            if 'No such customer:' not in message:
+                raise e
+            else:
+                return render_template('error.html', message=error_message)
     else:
         print('Form validation errors: {}'.format(form.errors))
         print('Did not validate form of customer {} {} {}'.format(

--- a/app.py
+++ b/app.py
@@ -244,7 +244,7 @@ def charge():
             gtm['event_value'] = request.form['amount']
             return render_template('charge.html',
                     amount=request.form['amount'], gtm=gtm, bundles=bundles)
-        except InvalidRequestError:
+        except stripe.error.InvalidRequestError:
             return render_template('error.html', message=error_message)
     else:
         print('Form validation errors: {}'.format(form.errors))

--- a/app.py
+++ b/app.py
@@ -251,6 +251,7 @@ def charge():
             if 'No such customer:' not in message:
                 raise e
             else:
+                print(message)
                 return render_template('error.html', message=error_message)
     else:
         print('Form validation errors: {}'.format(form.errors))


### PR DESCRIPTION
#### What's this PR do?
Puts the customer-retrieval portion of the Flask logic into a `try/except` block.

#### Why are we doing this? How does it help us?
Twice now, a rogue IP address has slammed this app's `/charge` URL with bogus customer IDs. It has burned through our free Sentry quota and caused annoyance in `#tech-alerts`. We blocked the questionable IP, but it's possible someone else could attempt the same thing.

So far as I can tell, there isn't a way to syntactically validate the customer ID. But trying to fetch a non-existent customer by ID throws a custom Stripe error (`InvalidRequestError`), so catching that exception should do the trick. In that case, we simply send users to an error page.

#### How should this be manually tested?
+ `make interactive`
+ `yarn run dev`
+ On `master`, do the cURL command below. Confirm you get a Python error in the response -- something like `Could not validate nonexistent customer foobarbaz`
+ Now, on this branch, do the same cURL. There should be an HTML response with the error page. Somewhere in that, it should say `There was an issue saving your donation information.`
+ On this branch, try making a donations with different amounts and frequencies. Confirm you get the "Thank you" page.

Command:
```
curl -d "amount=1&campaign_id=foobar&customerId=foobarbaz&description=hi&first_name=mugnypqo&installment_period=yearly&installments=None&last_name=mugnypqo&openended_status=Open&pay_fees_value=True&reason=1&stripeEmail=sample@email.tst&zipcode=94102" -H "Content-Type: application/x-www-form-urlencoded" -X POST http://local.texastribune.org/charge
```

#### Have automated tests been added?
No.

#### Has this been tested on mobile?
NA.

#### Are there performance implications?
No.

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/1242027477

#### How should this change be communicated to end users?
NA.

#### Next steps?
NA.

#### Smells?
Ideally we would just validate the syntax of a customer ID without having to catch an exception. But there doesn't seem to be a way to do that. Understandably so, too -- Stripe probably doesn't want to reveal its ID-generation secrets for security purposes.

#### TODOs:
NA.

#### Has the relevant documentation/wiki been updated?
Inline comment included.

#### Technical debt note
Same.