### PR TITLE
Charge new donations immediately

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ import logging
 import os
 from config import FLASK_DEBUG, FLASK_SECRET_KEY, LOG_LEVEL, TIMEZONE
 from datetime import datetime
+from pprint import pformat
 
 from pytz import timezone
 
@@ -25,6 +26,7 @@ from util import (
     send_multiple_account_warning,
 )
 from validate_email import validate_email
+from charges import charge
 
 ZONE = timezone(TIMEZONE)
 
@@ -152,11 +154,21 @@ def add_donation(form=None, customer=None):
     if period is None:
         logging.info("----Creating one time payment...")
         opportunity = add_opportunity(contact=contact, form=form, customer=customer)
+        charge(opportunity)
         logging.info(opportunity)
         notify_slack(contact=contact, opportunity=opportunity)
     else:
         logging.info("----Creating recurring payment...")
         rdo = add_recurring_donation(contact=contact, form=form, customer=customer)
+        # get opportunities
+        opportunities = rdo.opportunities()
+        today = datetime.now(tz=ZONE).strftime("%Y-%m-%d")
+        opp = [
+            opportunity
+            for opportunity in opportunities
+            if opportunity.expected_giving_date == today
+        ][0]
+        charge(opp)
         logging.info(rdo)
         notify_slack(contact=contact, rdo=rdo)
 
@@ -199,7 +211,7 @@ def do_charge_or_show_errors(template, bundles, function):
 
 
 def validate_form(FormType, bundles, template, function=add_donation.delay):
-    app.logger.info(request.form)
+    app.logger.info(pformat(request.form))
 
     form = FormType(request.form)
     email = request.form["stripeEmail"]
@@ -287,8 +299,7 @@ def the_blast_form():
 
 @app.route("/submit-blast", methods=["POST"])
 def submit_blast():
-
-    app.logger.info(request.form)
+    app.logger.info(pformat(request.form))
     form = BlastForm(request.form)
 
     email_is_valid = validate_email(request.form["stripeEmail"])
@@ -502,11 +513,21 @@ def add_business_membership(form=None, customer=None):
             account=account, form=form, customer=customer
         )
         logging.info(opportunity)
+        charge(opportunity)
         notify_slack(account=account, opportunity=opportunity)
     else:
         logging.info("----Creating recurring business membership...")
         rdo = add_business_rdo(account=account, form=form, customer=customer)
         logging.info(rdo)
+        # get opportunities
+        opportunities = rdo.opportunities()
+        today = datetime.now(tz=ZONE).strftime("%Y-%m-%d")
+        opp = [
+            opportunity
+            for opportunity in opportunities
+            if opportunity.expected_giving_date == today
+        ][0]
+        charge(opp)
         notify_slack(account=account, rdo=rdo)
 
     logging.info("----Getting affiliation...")
@@ -531,7 +552,6 @@ def add_blast_subscription(form=None, customer=None):
     """
 
     form = clean(form)
-    logging.info(form)
 
     first_name = form["first_name"]
     last_name = form["last_name"]
@@ -569,7 +589,15 @@ def add_blast_subscription(form=None, customer=None):
     logging.info("----Saving RDO....")
     rdo.save()
     logging.info(rdo)
-
+    # get opportunities
+    opportunities = rdo.opportunities()
+    today = datetime.now(tz=ZONE).strftime("%Y-%m-%d")
+    opp = [
+        opportunity
+        for opportunity in opportunities
+        if opportunity.expected_giving_date == today
+    ][0]
+    charge(opp)
     return True
 
 

--- a/batch.py
+++ b/batch.py
@@ -1,7 +1,6 @@
 import logging
 from config import ACCOUNTING_MAIL_RECIPIENT, LOG_LEVEL, REDIS_URL, TIMEZONE
 from datetime import datetime, timedelta
-from decimal import Decimal
 
 from pytz import timezone
 

--- a/npsp.py
+++ b/npsp.py
@@ -460,6 +460,10 @@ class RDO(SalesforceObject):
     def __str__(self):
         return f"{self.id}: {self.name} for {self.amount} ({self.description})"
 
+    # TODO sensible way to cache this to prevent it from being run multiple times when nothing 
+    # has changed? The opportunities themselves may've changed even when the RDO hasn't so 
+    # this may not be doable. 
+
     def opportunities(self):
         query = f"""
             SELECT Id, Amount, Name, Stripe_Customer_ID__c, Description,
@@ -543,13 +547,14 @@ class RDO(SalesforceObject):
         # SF side
         if self.record_type_name == DEFAULT_RDO_TYPE or self.record_type_name is None:
             return
-        logging.info(
-            f"Setting record type for {self} opportunities to {self.record_type_name}"
-        )
         if self.open_ended_status == "Open":
             logging.warning(
                 f"RDO {self} is open-ended so new opportunities won't have type {self.record_type_name}"
             )
+            return
+        logging.info(
+            f"Setting record type for {self} opportunities to {self.record_type_name}"
+        )
         update = {"RecordType": {"Name": self.record_type_name}}
         self.sf.update(self.opportunities(), update)
 

--- a/npsp.py
+++ b/npsp.py
@@ -460,9 +460,9 @@ class RDO(SalesforceObject):
     def __str__(self):
         return f"{self.id}: {self.name} for {self.amount} ({self.description})"
 
-    # TODO sensible way to cache this to prevent it from being run multiple times when nothing 
-    # has changed? The opportunities themselves may've changed even when the RDO hasn't so 
-    # this may not be doable. 
+    # TODO sensible way to cache this to prevent it from being run multiple times when nothing
+    # has changed? The opportunities themselves may've changed even when the RDO hasn't so
+    # this may not be doable.
 
     def opportunities(self):
         query = f"""


### PR DESCRIPTION
#### What's this PR do?

Charges new donations immediately instead of waiting for the batch job to run. This is a better replacement for PR #48.

#### Why are we doing this? How does it help us? 

The batch job was designed to run once or a few times daily. But at certain times (like membership drives) they need to have more up-to-date numbers. So we run the batch job more frequently. But we can only configure it to run at most once an hour. Moving charging for single donations and the initial charge for new recurring donations to the time of submission means those numbers are always up-to-date without having to run the batch job frequently. 

#### How should this be manually tested?

1. Run the project as normal. 
1. Make some test transactions. Try regular, recurring, Circle and Blast. 
1. Make sure you see a message about charging the card and a successful call to the Stripe API for it.

#### Have automated tests been added?

No, but existing ones have been modified.

#### Has this been tested on mobile?

N/A

#### Are there performance implications?

This will make it take longer to process a transaction. But since it's done asynchronously it won't mean any additional time for the user.

#### What are the relevant tickets?

Off-sprint.

#### How should this change be communicated to end users?

Let membership know that numbers will be up-to-date all the time.

#### Next steps?

None.

#### Smells?

None.

#### Has the relevant documentation/wiki been updated?

Not yet.