### PR TITLE
Enforce reason character limit client side

### DIFF
--- a/static/js/src/entry/circle/CircleForm.vue
+++ b/static/js/src/entry/circle/CircleForm.vue
@@ -70,10 +70,13 @@
         <div class="col_6 grid_separator">
           <text-input
             :required="false"
+            :show-error="showManualErrors || showNativeErrors"
+            :validation="validation.reason"
             label-text="encouraged to give by"
             base-classes="form__text form__text--standard"
             name="reason"
             store-module="circleForm"
+            @setValidationValue="setValidationValue"
           />
         </div>
         <div class="col_6 grid_separator">
@@ -271,6 +274,13 @@ export default {
           valid: false,
           message: 'Enter a 5-digit zip code',
           validator: this.isEmptyOrZip,
+        },
+        reason: {
+          manual: true,
+          native: true,
+          valid: false,
+          message: 'Must be 255 characters or fewer',
+          validator: this.isValidReason,
         },
       },
     };

--- a/static/js/src/entry/donate/TopForm.vue
+++ b/static/js/src/entry/donate/TopForm.vue
@@ -91,10 +91,13 @@
       <div class="col_6 grid_separator">
         <text-input
           :required="false"
+          :show-error="showManualErrors || showNativeErrors"
+          :validation="validation.reason"
           label-text="encouraged to give by"
           base-classes="form__text form__text--standard"
           name="reason"
           store-module="baseForm"
+          @setValidationValue="setValidationValue"
         />
       </div>
       <div class="col_6 grid_separator">
@@ -294,6 +297,13 @@ export default {
           valid: false,
           message: 'Enter a 5-digit zip code',
           validator: this.isEmptyOrZip,
+        },
+        reason: {
+          manual: true,
+          native: true,
+          valid: false,
+          message: 'Must be 255 characters or fewer',
+          validator: this.isValidReason,
         },
       },
     };

--- a/static/js/src/mixins/form/starter.js
+++ b/static/js/src/mixins/form/starter.js
@@ -85,6 +85,14 @@ export default {
       return typeof isValid === 'undefined';
     },
 
+    isURL(value) {
+      const isValid = validate(
+        { website: value.trim() },
+        { website: { url: true } },
+      );
+      return typeof isValid === 'undefined';
+    },
+
     isNumeric(value) {
       const isValid = validate(
         { value: value.trim() },
@@ -114,13 +122,8 @@ export default {
       return typeof isValid === 'undefined';
     },
 
-    isURL(value) {
-      const isValid = validate(
-        { website: value.trim() },
-        { website: {url: true} },
-      );
-      return typeof isValid === 'undefined';
+    isValidReason(value) {
+      return value.trim().length <= 255;
     },
-
   },
 };


### PR DESCRIPTION
#### What's this PR do?
Gives you an error message if you try to enter an "encouraged by" longer than 255 characters

#### Why are we doing this? How does it help us?
To line up with the server-side validation.

#### How should this be manually tested?
On both `/circleform` and `/donate`, try entering an encouraged-by longer than 255 characters. Confirm you can't submit the form until you shorten it.

#### How should this change be communicated to end users?
NA.

#### Are there any smells or added technical debt to note?
NA.

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/1403846031

#### Have you done the following, if applicable:

* [ ] Added automated tests? *(NA)*
* [ ] Tested manually on mobile? *(NA)*
* [ ] Checked for performance implications? *(NA)*
* [ ] Checked for security implications? *(NA)*
* [ ] Updated the documentation/wiki? *(NA)*

#### TODOs / next steps:
* [ ] There are character limits to enforce for the business-membership form. But I'll leave those to @valasensio because I don't know the status of that page's launch.